### PR TITLE
在route 里面定义post 请求, 传参数用req.body获取参数会为空

### DIFF
--- a/lib/components/http.js
+++ b/lib/components/http.js
@@ -53,7 +53,6 @@ var Http = function(app, opts) {
   this.http.set('port', this.port);
   this.http.set('host', this.host);
   this.http.use(createLogger(opts.logger));
-  this.http.use(express.bodyParser());
   this.http.use(express.urlencoded());
   this.http.use(express.json());
   this.http.use(express.methodOverride());

--- a/lib/components/http.js
+++ b/lib/components/http.js
@@ -53,6 +53,7 @@ var Http = function(app, opts) {
   this.http.set('port', this.port);
   this.http.set('host', this.host);
   this.http.use(createLogger(opts.logger));
+  this.http.use(express.bodyParser());
   this.http.use(express.urlencoded());
   this.http.use(express.json());
   this.http.use(express.methodOverride());


### PR DESCRIPTION
代码实例  

``` js
http.post("/test/user/notify", function(req, res){
    console.log(req.body)
    res.json({a: 111})
 })
```

使用

``` js
  // http.js 加入中间层转换就可以了
  this.http.use(express.bodyParser()); 
```
