### PR TITLE
修复在route文件夹下有空js文件的错误

### DIFF
--- a/lib/components/http.js
+++ b/lib/components/http.js
@@ -94,11 +94,14 @@ Http.prototype.loadRoutes = function() {
   assert.ok(fs.existsSync(routesPath), 'Cannot find route path: ' + routesPath);
 
   var self = this;
-  fs.readdirSync(routesPath).forEach(function(file) {
+  fs.readdirSync(routesPath).every(function(file) {
     if (/.js$/.test(file)) {
       var routePath = path.join(routesPath, file);
       // self.logger.info(routePath);
-      require(routePath)(self.app, self.http, self);
+      var fn = require(routePath);
+      if(typeof(fn) !== 'function') return true;
+      fn(self.app, self.http, self);
+      return true;
     }
   });
 }


### PR DESCRIPTION
当route文件夹下有空的js文件时，require(path)()会报错，forEach不支持continue，因此改用every，用return true来跳过!==‘function’的require